### PR TITLE
Fix race condition with two simultaneous events

### DIFF
--- a/esp-wifi-hal/src/wmac.rs
+++ b/esp-wifi-hal/src/wmac.rs
@@ -105,7 +105,8 @@ extern "C" fn interrupt_handler() {
         .write(|w| unsafe { w.bits(cause) });
     if cause & 0x1000024 != 0 {
         WIFI_RX_SIGNAL_QUEUE.put();
-    } else if cause & 0x80 != 0 {
+    }
+    if cause & 0x80 != 0 {
         let mut txq_complete_status = wifi.txq_state().tx_complete_status().read().bits();
         while txq_complete_status != 0 {
             let slot = txq_complete_status.trailing_zeros();
@@ -113,7 +114,8 @@ extern "C" fn interrupt_handler() {
             // We mask away, the bit for our slot.
             txq_complete_status &= !(1 << slot);
         }
-    } else if cause & 0x80000 != 0 {
+    }
+    if cause & 0x80000 != 0 {
         // Timeout
         let mut tx_error_status = wifi
             .txq_state()
@@ -127,7 +129,8 @@ extern "C" fn interrupt_handler() {
             // We mask away, the bit for our slot.
             tx_error_status &= !(1 << slot);
         }
-    } else if cause & 0x100 != 0 {
+    }
+    if cause & 0x100 != 0 {
         // Timeout
         let mut tx_error_status = wifi
             .txq_state()


### PR DESCRIPTION
if you both finish sending a packet, and receive a packet at the same time, only one interrupt fires, with the `cause` bits set for both events; but then we processed only one, leading to the TX waker not getting woken up, and waiting forever.

Restructuring the `else if` statements into `if` thing fixes it, but I guess a safeguard timer for releasing the TX slot after a certain blocking time would not hurt? Or even a panic if it's stuck, so we know if this happens? Anyways, that's work that is not necessary for this PR, but might be a useful future addition for robustness