### PR TITLE
esp-wifi-hal: release 0.3.0

### DIFF
--- a/esp-wifi-hal/Cargo.lock
+++ b/esp-wifi-hal/Cargo.lock
@@ -667,7 +667,7 @@ dependencies = [
 
 [[package]]
 name = "esp-wifi-hal"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bitfield-struct",
  "critical-section",

--- a/esp-wifi-hal/Cargo.toml
+++ b/esp-wifi-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "esp-wifi-hal"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Frostie314159 <frostie.neuenhausen@gmail.com>"]
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -964,7 +964,7 @@ dependencies = [
 
 [[package]]
 name = "esp-wifi-hal"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bitfield-struct 0.13.0",
  "critical-section",


### PR DESCRIPTION
The major change here is the introduction of the low level driver. See #8 