### PR TITLE
examples: Fix ieee80211 declaration in Cargo.toml.

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -177,9 +177,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
 dependencies = [
  "cfg-if",
 ]
@@ -1237,6 +1237,8 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 [[package]]
 name = "ieee80211"
 version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7418f9be3522922d6e87647eacd5275641f6c225cf4a444a64c31e366ac37559"
 dependencies = [
  "aes-kw",
  "bitfield-struct 0.11.0",

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -19,7 +19,6 @@ esp-backtrace = { version = "0.18.1", features = ["panic-handler", "println"] }
 # Misc
 log = "0.4.28"
 static_cell = { version = "2.1.1" }
-ieee80211 = { path = "../../../rust/ieee80211/" }
 embedded-io-async = "0.7.0"
 embassy-futures = "0.1.2"
 embassy-executor = "0.10.0"
@@ -30,6 +29,7 @@ embedded-io = "0.7.1"
 esp-rtos = { version = "0.3.0", features = ["embassy"] }
 esp-println = { version = "0.16.1", features = ["log-04"] }
 esp-bootloader-esp-idf = "0.5.0"
+ieee80211 = "0.5.9"
 
 [features]
 esp32 = [


### PR DESCRIPTION
I mistakenly pointed this to my local directory which contained the crate.