### PR TITLE
Fix RX validation

### DIFF
--- a/esp-wifi-hal/src/async_driver.rs
+++ b/esp-wifi-hal/src/async_driver.rs
@@ -1077,23 +1077,30 @@ mod private {
     impl AsyncTransmitExt for LowLevelDriver {}
 }
 fn is_rx_frame_valid(dma_descriptor: &mut DmaDescriptor) -> bool {
+    let dma_len = dma_descriptor.len();
     // Just to be safe.
-    let length_valid = RX_BUFFER_SIZE >= dma_descriptor.len();
-    // Sometimes the received buffer is length zero, so we check that there's room for the RX header.
-    let has_phy_header = dma_descriptor.len() >= BorrowedBuffer::RX_CONTROL_HEADER_LENGTH;
+    if RX_BUFFER_SIZE < dma_len
+        || !dma_descriptor.buffer.is_aligned()
+        || dma_len < BorrowedBuffer::RX_CONTROL_HEADER_LENGTH
+    {
+        return false;
+    }
 
-    // SAFETY: We validated, that the length can't be larger, than the pre allocated size for the buffer.
-    let buffer =
-        unsafe { core::slice::from_raw_parts(dma_descriptor.buffer, dma_descriptor.len()) };
+    // SAFETY: We validated, that the buffer has enough space for an RX header, and that the pointer aligned.
+    let raw_header = unsafe {
+        (dma_descriptor.buffer as *mut crate::esp_wifi_sys::include::wifi_pkt_rx_ctrl_t).as_ref()
+    };
+    if let Some(raw_header) = raw_header {
+        // This is ok, because the length of the MIC and FCS, which are removed by the HW, are shorter,
+        // than the RX control header.
+        if raw_header.sig_len() as usize >= dma_len {
+            return false;
+        }
+    } else {
+        return false;
+    }
 
-    let field_0x18 = u32::from_le_bytes(buffer[24..28].try_into().unwrap()) as usize;
-    // NOTE: These names are a lot more on the side of guesses, than other names here.
-    let l_sig_len = field_0x18 & 0xfff;
-    let ht_sig_len = (field_0x18 >> 0xc) & 0xfff;
-
-    let length_fields_valid = l_sig_len < dma_descriptor.len() && ht_sig_len < dma_descriptor.len();
-
-    length_valid && has_phy_header && length_fields_valid
+    true
 }
 /// A trait implemented by structs, that allow asynchronously receiving frames.
 pub trait AsyncReceive<'res>: HasDmaList<'res> {

--- a/esp-wifi-hal/src/async_driver.rs
+++ b/esp-wifi-hal/src/async_driver.rs
@@ -1045,14 +1045,14 @@ mod private {
                     Ok(_) => break,
                     Err(TxError::MacProtocol(MacProtocolError::AckTimeout)) => {
                         if let Some(ref mut contention_state) = edca_contention_state {
-                            trace!("Incremented LRC");
+                            trace!("TX: Incremented LRC");
                             contention_state.increment_lrc();
                             contention_state.reset_src();
                         }
                     }
                     Err(TxError::MacProtocol(_)) => {
                         if let Some(ref mut contention_state) = edca_contention_state {
-                            trace!("Incremented SRC");
+                            trace!("TX: Incremented SRC");
                             contention_state.increment_src();
                         }
                     }
@@ -1063,7 +1063,7 @@ mod private {
                 *byte &= !bit!(3);
             }
             if last_res.is_err() {
-                trace!("Transmission of MPDU failed.");
+                trace!("TX: MPDU TX failed");
             }
             last_res
         }
@@ -1113,16 +1113,15 @@ pub trait AsyncReceive<'res>: HasDmaList<'res> {
                     .lock(|dma_list| dma_list.borrow_mut().take_first())
                 {
                     if is_rx_frame_valid(current) {
-                        trace!("Received packet. len: {}", current.len());
+                        trace!("RX: Received MPDU. DMA len {}", current.len());
                         break current;
                     } else {
-                        trace!("Discarding frame due to invalid header.");
+                        trace!("RX: Discarding presumably invalid frame.");
                         self.dma_list_ref()
                             .lock(|dma_list| dma_list.borrow_mut().recycle(current));
                     }
                 }
                 WIFI_RX_SIGNAL_QUEUE.next().await;
-                trace!("Received empty packet.");
             };
 
             BorrowedBuffer {

--- a/esp-wifi-hal/src/dma_list.rs
+++ b/esp-wifi-hal/src/dma_list.rs
@@ -1,4 +1,4 @@
-use crate::{borrowed_buffer::BorrowedBuffer, ll::LowLevelDriver};
+use crate::ll::LowLevelDriver;
 use core::{mem::MaybeUninit, ptr::NonNull};
 
 use esp_hal::dma::{DmaDescriptor, DmaDescriptorFlags, Owner};
@@ -72,14 +72,6 @@ impl<const BUFFER_COUNT: usize, const BUFFER_SIZE: usize> DmaBufferSlab<BUFFER_C
     }
 }
 
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
-/// The DMA list was empty, so RX could not be started.
-///
-/// Usually something weird is going on, if you want to start RX, but all buffers were taken out of
-/// the list and not returned.
-pub struct DmaListEmptyError;
-
 /// The receive DMA list.
 pub struct DmaList {
     rx_chain_ptrs: Option<(NonNull<DmaDescriptor>, NonNull<DmaDescriptor>)>,
@@ -92,7 +84,8 @@ impl DmaList {
         last_ptr: NonNull<DmaDescriptor>,
         ll_driver: &'static LowLevelDriver,
     ) -> Self {
-        ll_driver.start_rx(base_ptr);
+        ll_driver.set_base_rx_descriptor(base_ptr);
+        ll_driver.start_rx();
 
         trace!("Initialized DMA list.");
         Self {
@@ -208,12 +201,8 @@ impl DmaList {
     ///
     /// This is only necessary, if you previously explicitly stopped the queue with
     /// [Self::stop_rx].
-    pub fn restart_rx(&mut self) -> Result<(), DmaListEmptyError> {
-        self.rx_chain_ptrs
-            .map(|(base_ptr, _)| {
-                self.ll_driver.start_rx(base_ptr);
-            })
-            .ok_or(DmaListEmptyError)
+    pub fn restart_rx(&mut self) {
+        self.ll_driver.start_rx();
     }
     /// Stop receiving frames.
     ///

--- a/esp-wifi-hal/src/dma_list.rs
+++ b/esp-wifi-hal/src/dma_list.rs
@@ -125,14 +125,14 @@ impl DmaList {
     /// Take the first [DMAListItem] out of the list.
     pub fn take_first(&mut self) -> Option<&'static mut DmaDescriptor> {
         let first = unsafe { self.rx_chain_ptrs?.0.as_mut() };
-        if first.flags.suc_eof() && first.len() >= BorrowedBuffer::RX_CONTROL_HEADER_LENGTH {
+        if first.flags.suc_eof() {
+            first.set_owner(Owner::Cpu);
             let next = first.next();
             if next.is_none() {
                 trace!("RX DMA: list empty");
             };
             self.set_rx_chain_base(next.map(NonNull::from));
             trace!("RX DMA: Took {:08x} from list", first as *mut _ as u32);
-            first.set_owner(Owner::Cpu);
 
             Some(first)
         } else {

--- a/esp-wifi-hal/src/dma_list.rs
+++ b/esp-wifi-hal/src/dma_list.rs
@@ -125,13 +125,13 @@ impl DmaList {
     /// Take the first [DMAListItem] out of the list.
     pub fn take_first(&mut self) -> Option<&'static mut DmaDescriptor> {
         let first = unsafe { self.rx_chain_ptrs?.0.as_mut() };
-        trace!("Taking buffer: {:x} from DMA list.", first as *mut _ as u32);
         if first.flags.suc_eof() && first.len() >= BorrowedBuffer::RX_CONTROL_HEADER_LENGTH {
             let next = first.next();
             if next.is_none() {
-                debug!("RX: Next DMA descriptor was none.");
+                trace!("RX DMA: list empty");
             };
             self.set_rx_chain_base(next.map(NonNull::from));
+            trace!("RX DMA: Took {:08x} from list", first as *mut _ as u32);
             first.set_owner(Owner::Cpu);
 
             Some(first)
@@ -161,10 +161,6 @@ impl DmaList {
     /// Returns a [DMAListItem] to the end of the list.
     pub fn recycle(&mut self, dma_list_descriptor: &mut DmaDescriptor) {
         dma_list_descriptor.reset_for_rx();
-        trace!(
-            "Returned buffer: {:x} to DMA list.",
-            dma_list_descriptor as *mut _ as u32
-        );
 
         // If the DMA list is not empty, we attach the descriptor to the end, reload the hardware
         // descriptors and set the last pointer to the descriptor, under some weird conditions.
@@ -186,6 +182,10 @@ impl DmaList {
         }
         // If the DMA list is empty, we make this descriptor the base.
         self.set_rx_chain_base(NonNull::new(dma_list_descriptor));
+        trace!(
+            "RX DMA: Returned {:08x} to list.",
+            dma_list_descriptor as *mut _ as u32
+        );
     }
     /// Log the stats about the DMA list.
     pub fn log_stats(&self) {
@@ -201,7 +201,7 @@ impl DmaList {
                     .map(|non_null| non_null.as_ptr() as u32)
                     .unwrap_or_default(),
             );
-            info!("DMA list: Next: {:x} Last: {:x}", rx_next, rx_last);
+            info!("RX DMA: Stats: Next: {:x} Last: {:x}", rx_next, rx_last);
         }
     }
     /// Start receiving frames.

--- a/esp-wifi-hal/src/ll.rs
+++ b/esp-wifi-hal/src/ll.rs
@@ -1085,14 +1085,15 @@ impl LowLevelDriver {
         f: impl Fn(HardwareTxQueue),
     ) {
         let raw_status = unsafe { Self::raw_tx_status(tx_result) };
-        (0..5)
-            .filter(|i| check_bit!(raw_status, bit!(i)))
-            .for_each(|queue| {
-                // For some reason the slot numbering needs to be reversed when working with the
-                // interrupt cause register.
-                (f)(HardwareTxQueue::from_hardware_slot(4 - queue).unwrap());
-                unsafe { Self::clear_tx_slot_bit(tx_result, queue) };
-            });
+        for queue in 0..5 {
+            if !check_bit!(raw_status, bit!(queue)) {
+                continue;
+            }
+            // For some reason the slot numbering needs to be reversed when working with the
+            // interrupt cause register.
+            (f)(HardwareTxQueue::from_hardware_slot(4 - queue).unwrap());
+            unsafe { Self::clear_tx_slot_bit(tx_result, queue) };
+        }
     }
     #[inline]
     /// Configure the status of a TX slot.

--- a/esp-wifi-hal/src/ll.rs
+++ b/esp-wifi-hal/src/ll.rs
@@ -827,8 +827,7 @@ impl LowLevelDriver {
     /// Start receiving frames.
     ///
     /// This will set the provided descriptor as the base of the RX DMA list and enable RX.
-    pub fn start_rx(&self, base_descriptor: NonNull<DmaDescriptor>) {
-        self.set_base_rx_descriptor(base_descriptor);
+    pub fn start_rx(&self) {
         unsafe {
             Self::set_rx_enable(true);
         }


### PR DESCRIPTION
The changes made in #17 did not properly work on the ESP32-S2, due to my use of absolute offsets in the header parsing. This has been fixed and tested. I also improved the log strings a little, optimized TX completion handling, and changed the [LowLevelDriver::start_rx] function to not require a pointer to the base of the list. This allows restarting RX, even if the list is empty.