### PR TITLE
Add experimental ESP32-C3 support

### DIFF
--- a/esp-wifi-hal/Cargo.lock
+++ b/esp-wifi-hal/Cargo.lock
@@ -546,7 +546,7 @@ dependencies = [
  "esp-synopsys-usb-otg",
  "esp32 0.40.2",
  "esp32c2",
- "esp32c3",
+ "esp32c3 0.32.3",
  "esp32c6",
  "esp32h2",
  "esp32s2 0.31.2",
@@ -610,8 +610,10 @@ dependencies = [
  "esp-metadata-generated 0.4.0",
  "esp-sync",
  "esp-wifi-sys-esp32",
+ "esp-wifi-sys-esp32c3",
  "esp-wifi-sys-esp32s2",
  "esp32 0.40.2",
+ "esp32c3 0.32.3",
  "esp32s2 0.31.2",
  "log",
 ]
@@ -636,6 +638,7 @@ dependencies = [
  "document-features",
  "esp-metadata-generated 0.5.0",
  "esp32 0.41.0",
+ "esp32c3 0.33.0",
  "esp32s2 0.32.0",
 ]
 
@@ -686,8 +689,10 @@ dependencies = [
  "esp-sync",
  "esp-wifi-rates",
  "esp-wifi-sys-esp32",
+ "esp-wifi-sys-esp32c3",
  "esp-wifi-sys-esp32s2",
  "esp32 0.40.2",
+ "esp32c3 0.32.3",
  "esp32s2 0.31.2",
  "log",
  "macro-bits",
@@ -711,6 +716,12 @@ name = "esp-wifi-sys-esp32"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2556f38f5292d9735d4e156e276815fc001c9a0a2be0544a575c5fb867129d24"
+
+[[package]]
+name = "esp-wifi-sys-esp32c3"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b290846b53db9a3965866964260220b67f2c41cc2dbc0b377e7136239fe168a7"
 
 [[package]]
 name = "esp-wifi-sys-esp32s2"
@@ -747,9 +758,16 @@ dependencies = [
 
 [[package]]
 name = "esp32c3"
-version = "0.32.2"
+version = "0.32.3"
+dependencies = [
+ "vcell",
+]
+
+[[package]]
+name = "esp32c3"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21e89ed62cf6c043a6d29c520b02a13b359ec8a75d67b65d4330ed717d15fe97"
+checksum = "ffb892f670ff857033c1624f99ecba1a3f3cafa05c45d734bc129388276715cf"
 dependencies = [
  "vcell",
 ]

--- a/esp-wifi-hal/Cargo.toml
+++ b/esp-wifi-hal/Cargo.toml
@@ -20,9 +20,13 @@ esp32 = { version = "=0.40.2", optional = true, features = [
 esp32s2 = { version = "=0.31.2", optional = true, features = [
   "critical-section",
 ] }
+esp32c3 = { version = "0.32", optional = true, features = [
+  "critical-section",
+] }
 
 esp-wifi-sys-esp32 = { version = "=0.2.0", optional = true }
 esp-wifi-sys-esp32s2 = { version = "=0.2.0", optional = true }
+esp-wifi-sys-esp32c3 = { version = "=0.2.0", optional = true }
 
 # Embassy dependencies
 embassy-futures = "0.1.2"
@@ -69,6 +73,13 @@ esp32s2 = [
   "esp-phy/esp32s2",
   "esp-sync/esp32s2",
 ]
+esp32c3 = [
+  "dep:esp32c3",
+  "esp-hal/esp32c3",
+  "esp-wifi-sys-esp32c3",
+  "esp-phy/esp32c3",
+  "esp-sync/esp32c3",
+]
 
 defmt = [
   "dep:defmt",
@@ -79,3 +90,7 @@ defmt = [
 ]
 log = ["dep:log", "defmt-or-log/log", "esp-phy/log-04", "esp-sync/log-04"]
 critical_section = []
+
+[patch.crates-io]
+# esp32c3 PAC with the reverse engineered WIFI block, generated from esp-pacs
+esp32c3 = { path = "../../esp-pacs/esp32c3" }

--- a/esp-wifi-hal/Cargo.toml
+++ b/esp-wifi-hal/Cargo.toml
@@ -92,5 +92,5 @@ log = ["dep:log", "defmt-or-log/log", "esp-phy/log-04", "esp-sync/log-04"]
 critical_section = []
 
 [patch.crates-io]
-# esp32c3 PAC with the reverse engineered WIFI block, generated from esp-pacs
-esp32c3 = { path = "../../esp-pacs/esp32c3" }
+# esp32c3 PAC with the Wi-Fi MAC register block (esp-rs/esp-pacs#510), on top of the 0.32.3 release.
+esp32c3 = { git = "https://github.com/okhsunrog/esp-pacs.git", rev = "9be190016260ef195c97f7aa5aa7c576a1646890" }

--- a/esp-wifi-hal/build.rs
+++ b/esp-wifi-hal/build.rs
@@ -7,6 +7,8 @@ const NOMAC_CHANNEL_SET: &str = "nomac_channel_set";
 /// `g_osi_funcs_p` is a variable in the ROM data area (parts of the Wi-Fi stack live in ROM), so it
 /// must be written at runtime instead of being defined by us.
 const OSI_FUNCS_IN_ROM: &str = "osi_funcs_in_rom";
+/// The TSF counters, TSF timers and TBTT generator are known.
+const TSF_TIMER_PRESENT: &str = "tsf_timer_present";
 
 const ESP32_META: &[&str] = &["esp32", NOMAC_CHANNEL_SET];
 const ESP32S2_META: &[&str] = &["esp32s2", PWR_INTERRUPT_PRESENT, OSI_FUNCS_REQUIRED];
@@ -15,6 +17,7 @@ const ESP32C3_META: &[&str] = &[
     PWR_INTERRUPT_PRESENT,
     OSI_FUNCS_REQUIRED,
     OSI_FUNCS_IN_ROM,
+    TSF_TIMER_PRESENT,
 ];
 
 fn main() {

--- a/esp-wifi-hal/build.rs
+++ b/esp-wifi-hal/build.rs
@@ -4,15 +4,26 @@ const PWR_INTERRUPT_PRESENT: &str = "pwr_interrupt_present";
 /// though.
 const OSI_FUNCS_REQUIRED: &str = "osi_funcs_required";
 const NOMAC_CHANNEL_SET: &str = "nomac_channel_set";
+/// `g_osi_funcs_p` is a variable in the ROM data area (parts of the Wi-Fi stack live in ROM), so it
+/// must be written at runtime instead of being defined by us.
+const OSI_FUNCS_IN_ROM: &str = "osi_funcs_in_rom";
 
 const ESP32_META: &[&str] = &["esp32", NOMAC_CHANNEL_SET];
 const ESP32S2_META: &[&str] = &["esp32s2", PWR_INTERRUPT_PRESENT, OSI_FUNCS_REQUIRED];
+const ESP32C3_META: &[&str] = &[
+    "esp32c3",
+    PWR_INTERRUPT_PRESENT,
+    OSI_FUNCS_REQUIRED,
+    OSI_FUNCS_IN_ROM,
+];
 
 fn main() {
     let meta = if cfg!(feature = "esp32") {
         ESP32_META
     } else if cfg!(feature = "esp32s2") {
         ESP32S2_META
+    } else if cfg!(feature = "esp32c3") {
+        ESP32C3_META
     } else {
         panic!("You must select exactly one chip.");
     };

--- a/esp-wifi-hal/src/async_driver.rs
+++ b/esp-wifi-hal/src/async_driver.rs
@@ -1095,7 +1095,19 @@ fn is_rx_frame_valid(dma_descriptor: &mut DmaDescriptor) -> bool {
     let l_sig_len = field_0x18 & 0xfff;
     let ht_sig_len = (field_0x18 >> 0xc) & 0xfff;
 
+    #[cfg(not(feature = "esp32c3"))]
     let length_fields_valid = l_sig_len < dma_descriptor.len() && ht_sig_len < dma_descriptor.len();
+    // The RX control header of the ESP32-C3 is 48 bytes and the word at 0x18 is not the length
+    // word (it rejected every OFDM frame). Validate the `sig_len` field of the header instead, so
+    // that the trailer length calculation of `BorrowedBuffer` can't underflow.
+    #[cfg(feature = "esp32c3")]
+    let length_fields_valid = {
+        let _ = (l_sig_len, ht_sig_len);
+        let header_len = BorrowedBuffer::RX_CONTROL_HEADER_LENGTH;
+        let sig_len = (u32::from_le_bytes(buffer[header_len - 4..header_len].try_into().unwrap())
+            & 0xfff) as usize;
+        has_phy_header && sig_len >= dma_descriptor.len() - header_len
+    };
 
     length_valid && has_phy_header && length_fields_valid
 }

--- a/esp-wifi-hal/src/async_driver.rs
+++ b/esp-wifi-hal/src/async_driver.rs
@@ -22,6 +22,8 @@ use crate::{
     dma_list::DmaList,
     sync::{HardwareTxResultSignal, SignalQueue},
 };
+#[cfg(tsf_timer_present)]
+use crate::{ll::TSF_TIMER_COUNT, sync::EventSignal};
 
 #[handler]
 fn mac_handler() {
@@ -63,9 +65,32 @@ fn mac_handler() {
 #[cfg(pwr_interrupt_present)]
 #[handler]
 fn pwr_handler() {
-    let _cause = unsafe { LowLevelDriver::get_and_clear_pwr_interrupt_cause() };
-    // We don't do anything yet.
+    let cause = unsafe { LowLevelDriver::get_and_clear_pwr_interrupt_cause() };
+    #[cfg(tsf_timer_present)]
+    {
+        for (timer, signal) in TSF_TIMER_SIGNALS.iter().enumerate() {
+            if cause.tsf_timer_fired(timer) {
+                signal.signal();
+            }
+        }
+        for (interface, signal) in TBTT_SIGNALS.iter().enumerate() {
+            if cause.tbtt_of_interface(interface) {
+                signal.signal();
+            }
+        }
+    }
+    #[cfg(not(tsf_timer_present))]
+    let _ = cause;
 }
+
+/// Signaled, when a TSF timer reaches its target.
+#[cfg(tsf_timer_present)]
+static TSF_TIMER_SIGNALS: [EventSignal; TSF_TIMER_COUNT] =
+    [const { EventSignal::new() }; TSF_TIMER_COUNT];
+/// Signaled, when the TBTT of an interface is reached.
+#[cfg(tsf_timer_present)]
+static TBTT_SIGNALS: [EventSignal; INTERFACE_COUNT] =
+    [const { EventSignal::new() }; INTERFACE_COUNT];
 
 /// Tracks the number of frames, that are still in the RX queue.
 static WIFI_RX_SIGNAL_QUEUE: SignalQueue = SignalQueue::new();
@@ -211,6 +236,88 @@ pub trait ChannelControl: HasLowLevelDriver {
         unsafe { self.ll_driver_ref() }.set_channel(channel_number);
         CURRENT_CHANNEL.store(channel_number, Ordering::Relaxed);
         Ok(())
+    }
+}
+/// Provides control over the TSF counters, the TSF timers and the TBTT generators.
+///
+/// All of these live in the PWR block of the MAC and report through the PWR interrupt.
+#[cfg(tsf_timer_present)]
+pub trait TsfControl: HasLowLevelDriver {
+    /// Read the TSF counter of an interface.
+    fn tsf_time(&self, interface: usize) -> Result<u64, OutOfBounds> {
+        WiFi::validate_interface(interface)?;
+        Ok(unsafe { self.ll_driver_ref() }.tsf_time(interface))
+    }
+    /// Load the TSF counter of an interface.
+    fn set_tsf_time(&mut self, interface: usize, time: u64) -> Result<(), OutOfBounds> {
+        WiFi::validate_interface(interface)?;
+        unsafe { self.ll_driver_ref() }.set_tsf_time(interface, time);
+        Ok(())
+    }
+    /// Start or stop the TSF counter of an interface.
+    fn set_tsf_enabled(&mut self, interface: usize, enabled: bool) -> Result<(), OutOfBounds> {
+        WiFi::validate_interface(interface)?;
+        unsafe { self.ll_driver_ref() }.set_tsf_enabled(interface, enabled);
+        Ok(())
+    }
+    /// Arm a TSF timer, so it fires when the low 32 bits of the TSF reach `target`.
+    ///
+    /// A previously pending event of that timer is discarded.
+    fn set_tsf_timer(&mut self, timer: usize, target: u32) -> Result<(), OutOfBounds> {
+        WiFi::validate_tsf_timer(timer)?;
+        let ll_driver = unsafe { self.ll_driver_ref() };
+        ll_driver.set_tsf_timer_enabled(timer, false);
+        TSF_TIMER_SIGNALS[timer].reset();
+        ll_driver.set_tsf_timer_target(timer, target);
+        ll_driver.set_tsf_timer_enabled(timer, true);
+        Ok(())
+    }
+    /// Disarm a TSF timer.
+    fn cancel_tsf_timer(&mut self, timer: usize) -> Result<(), OutOfBounds> {
+        WiFi::validate_tsf_timer(timer)?;
+        unsafe { self.ll_driver_ref() }.set_tsf_timer_enabled(timer, false);
+        TSF_TIMER_SIGNALS[timer].reset();
+        Ok(())
+    }
+    /// Wait until the TSF timer fires.
+    fn wait_for_tsf_timer(
+        &self,
+        timer: usize,
+    ) -> Result<impl Future<Output = ()> + Send + Sync + use<'_, Self>, OutOfBounds> {
+        WiFi::validate_tsf_timer(timer)?;
+        Ok(TSF_TIMER_SIGNALS[timer].wait())
+    }
+    /// Configure the TBTT generator of an interface.
+    ///
+    /// `interval` is the beacon interval in TUs and `early_time` how many microseconds before
+    /// the TBTT the event fires. TBTTs occur whenever the TSF counter of the interface is a
+    /// multiple of the interval, so load the TSF counter to control the phase.
+    fn set_tbtt(
+        &mut self,
+        interface: usize,
+        interval: u16,
+        early_time: u16,
+    ) -> Result<(), OutOfBounds> {
+        WiFi::validate_interface(interface)?;
+        unsafe { self.ll_driver_ref() }.set_tbtt(interface, interval, early_time);
+        Ok(())
+    }
+    /// Start or stop the TBTT generator of an interface.
+    fn set_tbtt_enabled(&mut self, interface: usize, enabled: bool) -> Result<(), OutOfBounds> {
+        WiFi::validate_interface(interface)?;
+        unsafe { self.ll_driver_ref() }.set_tbtt_enabled(interface, enabled);
+        if !enabled {
+            TBTT_SIGNALS[interface].reset();
+        }
+        Ok(())
+    }
+    /// Wait until the next TBTT of the interface.
+    fn wait_for_tbtt(
+        &self,
+        interface: usize,
+    ) -> Result<impl Future<Output = ()> + Send + Sync + use<'_, Self>, OutOfBounds> {
+        WiFi::validate_interface(interface)?;
+        Ok(TBTT_SIGNALS[interface].wait())
     }
 }
 /// Provides control over hardware key slots.
@@ -1447,6 +1554,16 @@ impl<'res> WiFi<'res> {
         })
     }
     /// Check if they key slot is valid.
+    /// Check that the TSF timer index is in bounds.
+    #[cfg(tsf_timer_present)]
+    pub const fn validate_tsf_timer(timer: usize) -> Result<(), OutOfBounds> {
+        if timer < TSF_TIMER_COUNT {
+            Ok(())
+        } else {
+            Err(OutOfBounds)
+        }
+    }
+    /// Check that the key slot index is in bounds.
     pub const fn validate_key_slot(key_slot: usize) -> Result<(), OutOfBounds> {
         if key_slot < KEY_SLOT_COUNT {
             Ok(())
@@ -1462,6 +1579,8 @@ impl HasLowLevelDriver for WiFi<'_> {
 }
 impl ChannelControl for WiFi<'_> {}
 impl CryptoControl for WiFi<'_> {}
+#[cfg(tsf_timer_present)]
+impl TsfControl for WiFi<'_> {}
 
 impl<'res> HasDmaList<'res> for WiFi<'res> {
     fn dma_list_ref(&self) -> &'res blocking_mutex::Mutex<DefaultRawMutex, RefCell<DmaList>> {

--- a/esp-wifi-hal/src/async_driver.rs
+++ b/esp-wifi-hal/src/async_driver.rs
@@ -302,7 +302,9 @@ pub trait CryptoControl: HasLowLevelDriver {
     fn dump_key_slot(&self, key_slot: usize) -> Result<(), OutOfBounds> {
         WiFi::validate_key_slot(key_slot)?;
 
-        let wifi = WIFI::regs();
+        // The PAC register block; on chips where esp-hal treats WIFI as a virtual
+        // peripheral (ESP32-C3) `WIFI::regs()` does not exist.
+        let wifi = unsafe { LowLevelDriver::regs() };
         let crypto_key_slot = wifi.crypto_key_slot(key_slot);
 
         let mut key_bytes = [0x00u8; 32];
@@ -352,7 +354,9 @@ pub trait CryptoControl: HasLowLevelDriver {
     }
     /// Dump the values of the crypto control registers.
     fn dump_crypto_config(&self) {
-        let wifi = WIFI::regs();
+        // The PAC register block; on chips where esp-hal treats WIFI as a virtual
+        // peripheral (ESP32-C3) `WIFI::regs()` does not exist.
+        let wifi = unsafe { LowLevelDriver::regs() };
         for (i, interface_crypto_control) in wifi
             .crypto_control()
             .interface_crypto_control_iter()

--- a/esp-wifi-hal/src/ffi.rs
+++ b/esp-wifi-hal/src/ffi.rs
@@ -4,7 +4,7 @@ use esp_hal::{clock::xtal_clock, ram};
 
 #[cfg(osi_funcs_required)]
 #[allow(non_upper_case_globals)]
-#[unsafe(no_mangle)]
+#[cfg_attr(not(osi_funcs_in_rom), unsafe(no_mangle))]
 #[ram]
 static g_osi_funcs_p: &crate::esp_wifi_sys::include::wifi_osi_funcs_t =
     &crate::esp_wifi_sys::include::wifi_osi_funcs_t {
@@ -119,7 +119,8 @@ static g_osi_funcs_p: &crate::esp_wifi_sys::include::wifi_osi_funcs_t =
         _coex_wifi_release: None,
         _coex_wifi_channel_set: None,
         _coex_event_duration_get: None,
-        _coex_pti_get: None,
+        // Called by `hal_init` (via `hal_coex_pti_init`) on the ESP32-C3.
+        _coex_pti_get: Some(coex_pti_get),
         _coex_schm_status_bit_clear: None,
         _coex_schm_status_bit_set: None,
         _coex_schm_interval_set: None,
@@ -149,6 +150,27 @@ static g_osi_funcs_p: &crate::esp_wifi_sys::include::wifi_osi_funcs_t =
 
         _magic: crate::esp_wifi_sys::include::ESP_WIFI_OS_ADAPTER_MAGIC as i32,
     };
+
+/// Point the ROM's `g_osi_funcs_p` at our OS adapter table.
+///
+/// On chips where parts of the Wi-Fi stack are in ROM, the variable is owned by the ROM and is
+/// normally filled in by `esp_wifi_init_internal`, which we never call.
+#[cfg(osi_funcs_in_rom)]
+pub(crate) unsafe fn install_osi_funcs() {
+    unsafe extern "C" {
+        #[link_name = "g_osi_funcs_p"]
+        static mut ROM_OSI_FUNCS_P: *const crate::esp_wifi_sys::include::wifi_osi_funcs_t;
+    }
+    unsafe {
+        ROM_OSI_FUNCS_P = g_osi_funcs_p as *const _;
+    }
+}
+
+/// Coexistence priority lookup. We have no coexistence, so report "no PTI" for every event.
+#[allow(unused)]
+unsafe extern "C" fn coex_pti_get(_event: u32, _pti: *mut u8) -> i32 {
+    0
+}
 
 #[ram]
 #[unsafe(no_mangle)]
@@ -242,6 +264,8 @@ unsafe extern "C" {
     }
     pub fn hal_init();
     pub fn tx_pwctrl_background(_: u8, _: u8);
+    #[cfg_attr(feature = "esp32c3", link_name = "rom_enable_wifi_agc")]
     pub fn enable_wifi_agc();
+    #[cfg_attr(feature = "esp32c3", link_name = "rom_disable_wifi_agc")]
     pub fn disable_wifi_agc();
 }

--- a/esp-wifi-hal/src/lib.rs
+++ b/esp-wifi-hal/src/lib.rs
@@ -108,6 +108,8 @@ pub mod prelude {
         ChannelAccessError, ControlFrameFilterConfig, EdcaAccessCategory, HardwareTxQueue,
         INTERFACE_COUNT, KEY_SLOT_COUNT, MacProtocolError, RxFilterBank,
     };
+    #[cfg(tsf_timer_present)]
+    pub use crate::ll::TSF_TIMER_COUNT;
     pub use crate::rates::*;
     pub use crate::sync::DropGuard;
 }

--- a/esp-wifi-hal/src/lib.rs
+++ b/esp-wifi-hal/src/lib.rs
@@ -81,6 +81,10 @@ cfg_select! {
         use esp32s2 as esp_pac;
         use esp_wifi_sys_esp32s2 as esp_wifi_sys;
     }
+    feature = "esp32c3" => {
+        use esp32c3 as esp_pac;
+        use esp_wifi_sys_esp32c3 as esp_wifi_sys;
+    }
     _ => {
         compile_error!("Adjust this for a new chip.");
     }

--- a/esp-wifi-hal/src/ll.rs
+++ b/esp-wifi-hal/src/ll.rs
@@ -203,9 +203,9 @@ interrupt_cause_struct! {
         /// A TBTT was reached or is about to be reached.
         ///
         /// NOTE: This is an unconfirmed assumption.
-        tbtt => [@chip(esp32s2) 0x1e],
+        tbtt => [@chip(esp32s2) 0x1e, @chip(esp32c3) 0x1e],
         /// We don't know them meaning of this yet.
-        tsf_timer => [@chip(esp32s2) 0x1e0]
+        tsf_timer => [@chip(esp32s2) 0x1e0, @chip(esp32c3) 0x1e0]
     }
 }
 
@@ -1162,19 +1162,15 @@ impl LowLevelDriver {
             .pmd(queue.hardware_slot())
             .read()
             .bits();
-        // The bit layout of PMD on the ESP32-C3 is not known yet (hal_mac_get_txq_pmd only
-        // extracts bits 16..23), so report success and log the raw value.
-        #[cfg(feature = "esp32c3")]
-        {
-            trace!("PMD: {:08x}", pmd);
-            return Ok(());
-        }
-        #[cfg(not(feature = "esp32c3"))]
+        // The layout is the same on all supported chips: `lmacProcessTxComplete` switches on
+        // bits 12..15 and passes bits 0..7 as the sub error to `lmacProcessTxRtsError` and
+        // `lmacProcessTxError`. On the ESP32-C3 `hal_mac_get_txq_pmd` only masks off bit 24.
+        // Bits 16..23 look like the RSSI of the response frame: around -40 dBm when an ACK
+        // arrived and around -90 dBm (noise floor) on a timeout.
+        trace!("PMD: {:08x}", pmd);
         let error = ((pmd >> 0xc) & 0xf) as u8;
-        #[cfg(not(feature = "esp32c3"))]
         let sub_error = (pmd & 0xff) as u8;
 
-        #[cfg(not(feature = "esp32c3"))]
         match error {
             0 => Ok(()),
             1 => {
@@ -1378,7 +1374,9 @@ impl LowLevelDriver {
             Self::regs_internal()
                 .ht_unknown(queue.hardware_slot())
                 .write(|w| unsafe {
-                    w.bits((frame_length as u32 & 0x7ffff) | 0x40_0000 | ((mcs as u32 & 0b111) << 28))
+                    w.bits(
+                        (frame_length as u32 & 0x7ffff) | 0x40_0000 | ((mcs as u32 & 0b111) << 28),
+                    )
                 });
             Self::regs_internal()
                 .plcp2(queue.hardware_slot())

--- a/esp-wifi-hal/src/ll.rs
+++ b/esp-wifi-hal/src/ll.rs
@@ -182,7 +182,7 @@ interrupt_cause_struct! {
         /// A frame was received.
         ///
         /// We don't know, what the individual bits mean, but this works.
-        rx => [0x100020, @chip(esp32) 0x4],
+        rx => [0x100020, @chip(esp32) 0x4, @chip(esp32c3) 0x1204000],
         /// A frame was transmitted successfully.
         tx_success => 0x80,
         /// A transmission timeout occured.
@@ -1162,9 +1162,19 @@ impl LowLevelDriver {
             .pmd(queue.hardware_slot())
             .read()
             .bits();
+        // The bit layout of PMD on the ESP32-C3 is not known yet (hal_mac_get_txq_pmd only
+        // extracts bits 16..23), so report success and log the raw value.
+        #[cfg(feature = "esp32c3")]
+        {
+            trace!("PMD: {:08x}", pmd);
+            return Ok(());
+        }
+        #[cfg(not(feature = "esp32c3"))]
         let error = ((pmd >> 0xc) & 0xf) as u8;
+        #[cfg(not(feature = "esp32c3"))]
         let sub_error = (pmd & 0xff) as u8;
 
+        #[cfg(not(feature = "esp32c3"))]
         match error {
             0 => Ok(()),
             1 => {
@@ -1258,6 +1268,44 @@ impl LowLevelDriver {
         interface: usize,
         key_slot: Option<u8>,
     ) {
+        #[cfg(feature = "esp32c3")]
+        {
+            // Layout from mac_tx_set_plcp1 of the ESP32-C3 blob: LEN 0..11, RATE 12..16,
+            // KEY_SLOT_ID 17.., IS_80211_N 25. The interface ID and the rate the hardware expects
+            // the response at live in the "misc" slot register (PAC: PLCP2).
+            let plcp1 = (frame_length as u32 & 0xfff)
+                | ((rate.as_hardware_rate() as u32 & 0x1f) << 12)
+                | ((key_slot.unwrap_or_default() as u32) << 17)
+                | ((matches!(rate, TxPhyRate::Ht(_)) as u32) << 25);
+            Self::regs_internal()
+                .plcp1(queue.hardware_slot())
+                .write(|w| unsafe { w.bits(plcp1) });
+            let response_rate: u32 = match rate {
+                TxPhyRate::HrDsss(_) => rate.as_hardware_rate() as u32,
+                TxPhyRate::Ofdm(_) => 0xb,
+                TxPhyRate::Ht(ht_rate) => {
+                    if ht_rate.mcs_index() % 8 <= 2 {
+                        0xb
+                    } else {
+                        0x9
+                    }
+                }
+            };
+            // Keep the bits hal_init leaves in this register (0x0040_0020 on the C3). Bit 5 is
+            // the "PLCP2" bit the S2 driver sets for every transmission.
+            Self::regs_internal()
+                .plcp2(queue.hardware_slot())
+                .modify(|r, w| unsafe {
+                    w.bits(
+                        (r.bits() & !((0xff << 6) | (0x3 << 28)))
+                            | (1 << 5)
+                            | (response_rate << 6)
+                            | ((interface as u32 & 0x3) << 28),
+                    )
+                });
+            return;
+        }
+        #[allow(unreachable_code)]
         Self::regs_internal()
             .plcp1(queue.hardware_slot())
             .write(|w| unsafe {
@@ -1285,6 +1333,13 @@ impl LowLevelDriver {
     ///
     /// Currently this doesn't do much, except setting a bit with unknown meaning to one.
     pub fn set_plcp2(&self, queue: HardwareTxQueue) {
+        // On the ESP32-C3 this register is written by `set_plcp1`.
+        #[cfg(feature = "esp32c3")]
+        {
+            let _ = queue;
+            return;
+        }
+        #[allow(unreachable_code)]
         Self::regs_internal()
             .plcp2(queue.hardware_slot())
             .write(|w| w.unknown().set_bit());
@@ -1306,6 +1361,31 @@ impl LowLevelDriver {
         is_short_gi: bool,
         frame_length: usize,
     ) {
+        #[cfg(feature = "esp32c3")]
+        {
+            // From mac_tx_set_htsig of the ESP32-C3 blob (non-STBC path).
+            Self::regs_internal()
+                .ht_sig(queue.hardware_slot())
+                .write(|w| unsafe {
+                    w.bits(
+                        (mcs as u32 & 0b111)
+                            | ((is_short_gi as u32) << 7)
+                            | ((frame_length as u32 & 0xffff) << 8)
+                            | (0b111 << 24)
+                            | (((mcs >= 8) as u32) << 31),
+                    )
+                });
+            Self::regs_internal()
+                .ht_unknown(queue.hardware_slot())
+                .write(|w| unsafe {
+                    w.bits((frame_length as u32 & 0x7ffff) | 0x40_0000 | ((mcs as u32 & 0b111) << 28))
+                });
+            Self::regs_internal()
+                .plcp2(queue.hardware_slot())
+                .modify(|r, w| unsafe { w.bits((r.bits() & 0xff3f_ffff) | 0x40_0000) });
+            return;
+        }
+        #[allow(unreachable_code)]
         Self::regs_internal()
             .ht_sig(queue.hardware_slot())
             .write(|w| unsafe {

--- a/esp-wifi-hal/src/ll.rs
+++ b/esp-wifi-hal/src/ll.rs
@@ -22,6 +22,9 @@ cfg_select! {
 
         use esp_hal::peripherals::SYSCON;
     }
+    feature = "esp32c3" => {
+        use esp_hal::peripherals::APB_CTRL as SYSCON;
+    }
 }
 
 use esp_phy::{PhyInitGuard, enable_phy};
@@ -497,7 +500,7 @@ impl From<EdcaAccessCategory> for HardwareTxQueue {
     }
 }
 
-#[cfg(any(feature = "esp32", feature = "esp32s2"))]
+#[cfg(any(feature = "esp32", feature = "esp32s2", feature = "esp32c3"))]
 /// The number of "interfaces" supported by the hardware.
 pub const INTERFACE_COUNT: usize = 4;
 
@@ -600,7 +603,7 @@ impl LowLevelDriver {
     unsafe fn reset_mac(&self) {
         // Perform a full reset of the Wi-Fi module.
         cfg_select! {
-            any(feature = "esp32", feature = "esp32s2") => {
+            any(feature = "esp32", feature = "esp32s2", feature = "esp32c3") => {
                 let syscon = SYSCON::regs();
                 syscon.wifi_rst_en().modify(|_, w| w.mac_rst().set_bit());
                 syscon.wifi_rst_en().modify(|_, w| w.mac_rst().clear_bit());
@@ -631,6 +634,12 @@ impl LowLevelDriver {
                 const MAC_INIT_MASK: u32 = 0xff00efff;
                 const MAC_READY_MASK: u32 = 0x6000;
             }
+            feature = "esp32c3" => {
+                // From hal_mac_init/hal_mac_deinit in the ESP32-C3 libpp blob: the same bits as
+                // on the ESP32-S2, in the CTRL register at offset 0xca0.
+                const MAC_INIT_MASK: u32 = 0xff00efff;
+                const MAC_READY_MASK: u32 = 0x6000;
+            }
             _ => {
                 compile_error!("The MAC init mask may have to be updated for different chips.");
             }
@@ -638,7 +647,7 @@ impl LowLevelDriver {
         // Spin until the MAC state is marked as ready.
         // This is only required on the ESP32-S2.
         while !intialized
-            && cfg!(feature = "esp32s2")
+            && cfg!(any(feature = "esp32s2", feature = "esp32c3"))
             && Self::regs_internal().ctrl().read().bits() & MAC_READY_MASK != 0
         {}
         // If we are initializing the MAC, we need to clear some bits, by masking the reg, with the
@@ -664,6 +673,8 @@ impl LowLevelDriver {
         // be moved to open source code. In the meantime, we do the init, that we already understand a
         // second time in open source code, which should have no bad effects.
         unsafe {
+            #[cfg(osi_funcs_in_rom)]
+            crate::ffi::install_osi_funcs();
             hal_init();
         }
 
@@ -704,6 +715,8 @@ impl LowLevelDriver {
         let enable_mask = cfg_select! {
             feature = "esp32" => 0x00000406,
             feature = "esp32s2" => 0x000007cf,
+            // SYSTEM_WIFI_CLK_EN as used by esp_perip_clk_init in ESP-IDF (and esp-radio).
+            feature = "esp32c3" => 0x00fb9fcf,
             _ => compile_error!("If you're adding a new chip, you have to adjust the modem clock enable mask.")
         };
         SYSCON::regs()

--- a/esp-wifi-hal/src/ll.rs
+++ b/esp-wifi-hal/src/ll.rs
@@ -200,12 +200,25 @@ interrupt_cause_struct! {
 interrupt_cause_struct! {
     /// Cause for the power interrupt.
     PwrInterruptCause => {
-        /// A TBTT was reached or is about to be reached.
+        /// A TBTT of one of the interfaces was reached or is about to be reached.
         ///
-        /// NOTE: This is an unconfirmed assumption.
+        /// Interface `n` uses bit `4 - n`.
         tbtt => [@chip(esp32s2) 0x1e, @chip(esp32c3) 0x1e],
-        /// We don't know them meaning of this yet.
+        /// One of the TSF timers reached its target.
+        ///
+        /// Timer `n` uses bit `8 - n`.
         tsf_timer => [@chip(esp32s2) 0x1e0, @chip(esp32c3) 0x1e0]
+    }
+}
+#[cfg(tsf_timer_present)]
+impl PwrInterruptCause {
+    /// Was the TBTT of the specified interface reached.
+    pub const fn tbtt_of_interface(&self, interface: usize) -> bool {
+        interface < INTERFACE_COUNT && self.0 & (0x10 >> interface) != 0
+    }
+    /// Did the specified TSF timer reach its target.
+    pub const fn tsf_timer_fired(&self, timer: usize) -> bool {
+        timer < TSF_TIMER_COUNT && self.0 & (0x100 >> timer) != 0
     }
 }
 
@@ -503,6 +516,9 @@ impl From<EdcaAccessCategory> for HardwareTxQueue {
 #[cfg(any(feature = "esp32", feature = "esp32s2", feature = "esp32c3"))]
 /// The number of "interfaces" supported by the hardware.
 pub const INTERFACE_COUNT: usize = 4;
+/// The number of TSF timers the hardware has.
+#[cfg(tsf_timer_present)]
+pub const TSF_TIMER_COUNT: usize = 4;
 
 /// The number of key slots the hardware has.
 pub const KEY_SLOT_COUNT: usize = 25;
@@ -1625,6 +1641,137 @@ impl LowLevelDriver {
     pub fn run_power_control(&self) {
         unsafe {
             tx_pwctrl_background(1, 0);
+        }
+    }
+}
+
+// TSF, TSF timers and TBTT.
+//
+// Register usage derived from the `tsf_hal_*` functions of the ESP32-C3 blob. Timer and TBTT
+// events arrive through the PWR interrupt.
+#[cfg(tsf_timer_present)]
+impl LowLevelDriver {
+    /// Read the TSF counter of an interface.
+    ///
+    /// The counter is latched, read and unlatched, like `tsf_hal_get_counter_value` does.
+    pub fn tsf_time(&self, interface: usize) -> u64 {
+        let regs = Self::regs_internal();
+        let bit = 1u8 << interface;
+        regs.tsf_ctrl()
+            .modify(|r, w| unsafe { w.latch().bits(r.latch().bits() | bit) });
+        let low = regs.tsf_time_low().read().bits();
+        let high = regs.tsf_time_high().read().bits();
+        regs.tsf_ctrl()
+            .modify(|r, w| unsafe { w.latch().bits(r.latch().bits() & !bit) });
+        (high as u64) << 32 | low as u64
+    }
+    /// Load the TSF counter of an interface.
+    pub fn set_tsf_time(&self, interface: usize, time: u64) {
+        let regs = Self::regs_internal();
+        regs.tsf_load_low()
+            .write(|w| unsafe { w.bits(time as u32) });
+        regs.tsf_load_high()
+            .write(|w| unsafe { w.bits((time >> 32) as u32) });
+        regs.tsf_ctrl()
+            .modify(|r, w| unsafe { w.load().bits(r.load().bits() | 1 << interface) });
+    }
+    /// Is the TSF counter of the interface running.
+    pub fn tsf_enabled(&self, interface: usize) -> bool {
+        Self::regs_internal()
+            .tsf_cfg(interface)
+            .read()
+            .tsf_enable()
+            .bit_is_set()
+    }
+    /// Start or stop the TSF counter of an interface.
+    ///
+    /// Bits 27 and 28 are set and cleared together with the enable bit, since the blob does so
+    /// and their meaning is unknown.
+    pub fn set_tsf_enabled(&self, interface: usize, enabled: bool) {
+        Self::regs_internal()
+            .tsf_cfg(interface)
+            .modify(|_, w| unsafe {
+                w.tsf_enable()
+                    .bit(enabled)
+                    .tsf_enable_aux()
+                    .bits(if enabled { 0b11 } else { 0 })
+            });
+    }
+    /// Set the target of a TSF timer.
+    ///
+    /// The target is compared against the low 32 bits of the TSF.
+    pub fn set_tsf_timer_target(&self, timer: usize, target: u32) {
+        Self::regs_internal()
+            .tsf_timer_target(timer)
+            .write(|w| unsafe { w.bits(target) });
+    }
+    /// Get the target of a TSF timer.
+    pub fn tsf_timer_target(&self, timer: usize) -> u32 {
+        Self::regs_internal().tsf_timer_target(timer).read().bits()
+    }
+    /// Start or stop a TSF timer and unmask or mask its PWR interrupt.
+    pub fn set_tsf_timer_enabled(&self, timer: usize, enabled: bool) {
+        let regs = Self::regs_internal();
+        let bit = 0x100u32 >> timer;
+        if enabled {
+            // Discard a stale event before unmasking, like `tsf_hal_set_timer_intr_enable`.
+            regs.pwr_interrupt()
+                .pwr_int_clear()
+                .write(|w| unsafe { w.bits(bit) });
+            regs.pwr_int_enable()
+                .modify(|r, w| unsafe { w.bits(r.bits() | bit) });
+            regs.tsf_timer_cfg(timer)
+                .modify(|_, w| w.enable().set_bit());
+        } else {
+            regs.tsf_timer_cfg(timer)
+                .modify(|_, w| w.enable().clear_bit());
+            regs.pwr_int_enable()
+                .modify(|r, w| unsafe { w.bits(r.bits() & !bit) });
+        }
+    }
+    /// Configure the TBTT generator of an interface.
+    ///
+    /// `interval` is the beacon interval in TUs and `early_time` is how many microseconds before
+    /// the TBTT the event fires. The meaning of `early_time` is derived from the name
+    /// `tsf_hal_set_tbtt_early_time` only.
+    ///
+    /// TBTTs occur whenever the TSF counter of the interface is a multiple of the interval, as
+    /// 802.11 defines them, so the phase is controlled by loading the TSF counter.
+    pub fn set_tbtt(&self, interface: usize, interval: u16, early_time: u16) {
+        Self::regs_internal()
+            .tbtt_cfg(interface)
+            .write(|w| unsafe { w.interval().bits(interval).early_time().bits(early_time) });
+    }
+    /// Set the TBTT start time of an interface.
+    ///
+    /// The blob writes the TSF time of the most recent TBTT here (only the low 26 bits). It does
+    /// not affect when TBTT events fire, so its purpose is unknown.
+    pub fn set_tbtt_start_time(&self, interface: usize, start_time: u32) {
+        let regs = Self::regs_internal();
+        regs.tbtt_start()
+            .write(|w| unsafe { w.start_time().bits(start_time & 0x3ff_ffff) });
+        regs.tsf_ctrl().modify(|r, w| unsafe {
+            w.load_tbtt_start()
+                .bits(r.load_tbtt_start().bits() | 1 << interface)
+        });
+    }
+    /// Start or stop the TBTT generator of an interface and unmask or mask its PWR interrupt.
+    pub fn set_tbtt_enabled(&self, interface: usize, enabled: bool) {
+        let regs = Self::regs_internal();
+        let bit = 0x10u32 >> interface;
+        if enabled {
+            regs.pwr_interrupt()
+                .pwr_int_clear()
+                .write(|w| unsafe { w.bits(bit) });
+            regs.pwr_int_enable()
+                .modify(|r, w| unsafe { w.bits(r.bits() | bit) });
+            regs.tsf_cfg(interface)
+                .modify(|_, w| w.tbtt_enable().set_bit());
+        } else {
+            regs.tsf_cfg(interface)
+                .modify(|_, w| w.tbtt_enable().clear_bit());
+            regs.pwr_int_enable()
+                .modify(|r, w| unsafe { w.bits(r.bits() & !bit) });
         }
     }
 }

--- a/esp-wifi-hal/src/sync.rs
+++ b/esp-wifi-hal/src/sync.rs
@@ -4,7 +4,7 @@ use core::{
 };
 
 use esp_hal::asynch::AtomicWaker;
-use portable_atomic::{AtomicU8, AtomicUsize, Ordering};
+use portable_atomic::{AtomicBool, AtomicU8, AtomicUsize, Ordering};
 
 use crate::ll::ChannelAccessError;
 
@@ -62,6 +62,45 @@ impl HardwareTxResultSignal {
                         Self::COLLISION => Err(ChannelAccessError::Collision),
                         _ => unreachable!(),
                     })
+                } else {
+                    self.waker.register(cx.waker());
+                    Poll::Pending
+                }
+            })
+        })
+    }
+}
+
+/// A primitive for signaling, that a hardware event occured.
+///
+/// Multiple events before the next wait collapse into one.
+pub struct EventSignal {
+    fired: AtomicBool,
+    waker: AtomicWaker,
+}
+impl EventSignal {
+    /// Create a new event signal.
+    pub const fn new() -> Self {
+        Self {
+            fired: AtomicBool::new(false),
+            waker: AtomicWaker::new(),
+        }
+    }
+    /// Signal, that the event occured.
+    pub fn signal(&self) {
+        self.fired.store(true, Ordering::Release);
+        self.waker.wake();
+    }
+    /// Discard a pending event.
+    pub fn reset(&self) {
+        self.fired.store(false, Ordering::Release);
+    }
+    /// Wait for the next event.
+    pub fn wait(&self) -> impl Future<Output = ()> + Send + Sync + use<'_> {
+        poll_fn(|cx| {
+            esp_sync::RawMutex::new().lock(|| {
+                if self.fired.swap(false, Ordering::AcqRel) {
+                    Poll::Ready(())
                 } else {
                     self.waker.register(cx.waker());
                     Poll::Pending

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1034,6 +1034,7 @@ dependencies = [
 [[package]]
 name = "esp32c3"
 version = "0.32.3"
+source = "git+https://github.com/okhsunrog/esp-pacs.git?rev=9be190016260ef195c97f7aa5aa7c576a1646890#9be190016260ef195c97f7aa5aa7c576a1646890"
 dependencies = [
  "vcell",
 ]

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -845,8 +845,10 @@ dependencies = [
  "esp-metadata-generated 0.4.0",
  "esp-sync 0.2.1",
  "esp-wifi-sys-esp32",
+ "esp-wifi-sys-esp32c3",
  "esp-wifi-sys-esp32s2",
  "esp32",
+ "esp32c3",
  "esp32s2",
  "log",
 ]
@@ -885,6 +887,7 @@ dependencies = [
  "document-features",
  "esp-metadata-generated 0.4.0",
  "esp32",
+ "esp32c3",
  "esp32s2",
 ]
 
@@ -971,8 +974,10 @@ dependencies = [
  "esp-sync 0.2.1",
  "esp-wifi-rates",
  "esp-wifi-sys-esp32",
+ "esp-wifi-sys-esp32c3",
  "esp-wifi-sys-esp32s2",
  "esp32",
+ "esp32c3",
  "esp32s2",
  "log",
  "macro-bits",
@@ -995,6 +1000,12 @@ name = "esp-wifi-sys-esp32"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2556f38f5292d9735d4e156e276815fc001c9a0a2be0544a575c5fb867129d24"
+
+[[package]]
+name = "esp-wifi-sys-esp32c3"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b290846b53db9a3965866964260220b67f2c41cc2dbc0b377e7136239fe168a7"
 
 [[package]]
 name = "esp-wifi-sys-esp32s2"
@@ -1022,9 +1033,7 @@ dependencies = [
 
 [[package]]
 name = "esp32c3"
-version = "0.32.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21e89ed62cf6c043a6d29c520b02a13b359ec8a75d67b65d4330ed717d15fe97"
+version = "0.32.3"
 dependencies = [
  "vcell",
 ]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -69,4 +69,5 @@ opt-level = 's'
 overflow-checks = false
 
 [patch.crates-io]
-esp32c3 = { path = "../../esp-pacs/esp32c3" }
+# esp32c3 PAC with the Wi-Fi MAC register block (esp-rs/esp-pacs#510), on top of the 0.32.3 release.
+esp32c3 = { git = "https://github.com/okhsunrog/esp-pacs.git", rev = "9be190016260ef195c97f7aa5aa7c576a1646890" }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -46,6 +46,13 @@ esp32s2 = [
     "esp-backtrace/esp32s2",
     "esp-bootloader-esp-idf/esp32s2",
 ]
+esp32c3 = [
+    "esp-wifi-hal/esp32c3",
+    "esp-hal/esp32c3",
+    "esp-rtos/esp32c3",
+    "esp-backtrace/esp32c3",
+    "esp-bootloader-esp-idf/esp32c3",
+]
 
 [profile.dev]
 # Rust debug is too slow.
@@ -60,3 +67,6 @@ incremental = false
 lto = 'fat'
 opt-level = 's'
 overflow-checks = false
+
+[patch.crates-io]
+esp32c3 = { path = "../../esp-pacs/esp32c3" }

--- a/examples/src/bin/acktest.rs
+++ b/examples/src/bin/acktest.rs
@@ -1,0 +1,50 @@
+//! RX + hardware auto-ACK test for the ESP32-C3.
+//!
+//! Installs the module's own MAC address as the receiver-address filter on interface 0 and then
+//! just receives. When a unicast frame addressed to this MAC arrives, the MAC hardware is expected
+//! to auto-ACK it. Inject such a frame from another device and watch for the ACK on that device.
+#![no_std]
+#![no_main]
+use embassy_executor::Spawner;
+use esp_backtrace as _;
+use esp_hal::efuse::base_mac_address;
+use esp_println::println;
+use esp_wifi_hal::prelude::*;
+use examples::{common_init, embassy_init, get_test_channel, wifi_init};
+
+#[esp_rtos::main]
+async fn main(_spawner: Spawner) {
+    let peripherals = common_init();
+    embassy_init(peripherals.TIMG0, peripherals.SW_INTERRUPT);
+    let mut wifi = wifi_init(peripherals.WIFI);
+
+    let mac: [u8; 6] = base_mac_address().as_bytes().try_into().unwrap();
+    let channel = get_test_channel();
+    let _ = wifi.set_channel(channel);
+
+    // Only frames whose receiver address matches ours pass the filter, so the hardware treats
+    // them as "for us" and ACKs them. No BSSID requirement.
+    let _ = wifi.set_filter(0, RxFilterBank::ReceiverAddress, mac);
+    let _ = wifi.set_filter_bssid_check(0, false);
+    let _ = wifi.set_scanning_mode(0, ScanningMode::Disabled);
+
+    println!(
+        "acktest: ch {channel}, my mac {:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
+        mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]
+    );
+
+    let mut count: u32 = 0;
+    loop {
+        let received = wifi.receive().await;
+        count += 1;
+        let mpdu = received.mpdu_buffer();
+        let fc = mpdu.first().copied().unwrap_or(0);
+        println!(
+            "#{count} fc={fc:02x} rssi={} rate={:?} len={} hdr={:02x?}",
+            received.rssi(),
+            received.phy_rate(),
+            mpdu.len(),
+            &mpdu[..mpdu.len().min(24)]
+        );
+    }
+}

--- a/examples/src/bin/sniffer.rs
+++ b/examples/src/bin/sniffer.rs
@@ -1,0 +1,73 @@
+//! Passive sniffer: puts interface 0 into scanning mode and prints every received frame.
+//!
+//! Used as the first hardware test of the ESP32-C3 port: if beacons show up here, the RX path
+//! (PHY init, MAC init, DMA list, filters and the MAC interrupt) works.
+#![no_std]
+#![no_main]
+use embassy_executor::Spawner;
+use esp_backtrace as _;
+use esp_println::println;
+use esp_wifi_hal::prelude::*;
+use examples::{common_init, embassy_init, get_test_channel, wifi_init};
+use ieee80211::{mgmt_frame::BeaconFrame, scroll::Pread};
+
+fn fmt_addr(b: &[u8]) -> [u8; 17] {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = [b':'; 17];
+    for (i, byte) in b.iter().take(6).enumerate() {
+        out[i * 3] = HEX[(byte >> 4) as usize];
+        out[i * 3 + 1] = HEX[(byte & 0xf) as usize];
+    }
+    out
+}
+
+#[esp_rtos::main]
+async fn main(_spawner: Spawner) {
+    let peripherals = common_init();
+    embassy_init(peripherals.TIMG0, peripherals.SW_INTERRUPT);
+    let mut wifi = wifi_init(peripherals.WIFI);
+
+    let channel = get_test_channel();
+    let _ = wifi.set_channel(channel);
+    let _ = wifi.set_scanning_mode(0, ScanningMode::ManagementAndData);
+    println!("sniffer: listening on channel {channel}");
+
+    let mut count: u32 = 0;
+    loop {
+        let received = wifi.receive().await;
+        count += 1;
+        let mpdu = received.mpdu_buffer();
+        if mpdu.len() < 24 {
+            println!("#{count} short frame len={} rssi={}", mpdu.len(), received.rssi());
+            continue;
+        }
+        let fc = mpdu[0];
+        let ftype = (fc >> 2) & 3;
+        let subtype = fc >> 4;
+        let a1 = fmt_addr(&mpdu[4..10]);
+        let a2 = fmt_addr(&mpdu[10..16]);
+        let a3 = fmt_addr(&mpdu[16..22]);
+        let a1 = core::str::from_utf8(&a1).unwrap();
+        let a2 = core::str::from_utf8(&a2).unwrap();
+        let a3 = core::str::from_utf8(&a3).unwrap();
+        if ftype == 0 && subtype == 8 {
+            let ssid = mpdu
+                .pread::<BeaconFrame>(0)
+                .ok()
+                .and_then(|b| b.ssid())
+                .unwrap_or("<no ssid>");
+            println!(
+                "#{count} beacon bssid={a3} ssid={ssid:?} rssi={} rate={:?} len={}",
+                received.rssi(),
+                received.phy_rate(),
+                mpdu.len()
+            );
+        } else {
+            println!(
+                "#{count} type={ftype} subtype={subtype} a1={a1} a2={a2} a3={a3} rssi={} len={}",
+                received.rssi(),
+                mpdu.len()
+            );
+        }
+    }
+}

--- a/examples/src/bin/tsf_timer_test.rs
+++ b/examples/src/bin/tsf_timer_test.rs
@@ -1,0 +1,102 @@
+//! TSF timer and TBTT test.
+//!
+//! Enables the TSF counter of interface 0, arms TSF timer 0 one second ahead a few times and
+//! measures how long the PWR interrupt takes to arrive. Then configures the TBTT generator of
+//! interface 0 with a 100 TU beacon interval and prints the spacing and phase of the TBTT events.
+#![no_std]
+#![no_main]
+
+use embassy_executor::Spawner;
+use embassy_futures::select::{Either, select};
+use embassy_time::{Duration, Timer};
+use esp_backtrace as _;
+use esp_println::println;
+use esp_wifi_hal::prelude::*;
+use examples::{common_init, embassy_init, get_test_channel, wifi_init};
+
+const TU: u32 = 1024;
+
+#[esp_rtos::main]
+async fn main(_spawner: Spawner) {
+    let peripherals = common_init();
+    embassy_init(peripherals.TIMG0, peripherals.SW_INTERRUPT);
+    let mut wifi = wifi_init(peripherals.WIFI);
+    let _ = wifi.set_channel(get_test_channel());
+
+    println!(
+        "tsf_timer_test: tsf0 enabled={} tsf0={} mac_time={}",
+        unsafe { wifi.ll_driver_ref() }.tsf_enabled(0),
+        wifi.tsf_time(0).unwrap(),
+        wifi.mac_time().duration_since_epoch().as_micros()
+    );
+    wifi.set_tsf_enabled(0, true).unwrap();
+    wifi.set_tsf_time(0, 0).unwrap();
+    Timer::after_millis(10).await;
+    println!(
+        "after enable: tsf0={} mac_time={}",
+        wifi.tsf_time(0).unwrap(),
+        wifi.mac_time().duration_since_epoch().as_micros()
+    );
+
+    // TSF timer 0: fire one second after now, five times.
+    for round in 0..5 {
+        let now = wifi.tsf_time(0).unwrap();
+        let target = (now as u32).wrapping_add(1_000_000);
+        let mac_before = wifi.mac_time();
+        wifi.set_tsf_timer(0, target).unwrap();
+        let waiter = wifi.wait_for_tsf_timer(0).unwrap();
+        match select(waiter, Timer::after(Duration::from_secs(3))).await {
+            Either::First(()) => {
+                let fired_at = wifi.tsf_time(0).unwrap();
+                println!(
+                    "timer #{round}: target={target} fired at tsf={fired_at} (+{} us tsf, +{} us mac)",
+                    fired_at.wrapping_sub(now),
+                    (wifi.mac_time() - mac_before).as_micros()
+                );
+            }
+            Either::Second(()) => {
+                println!(
+                    "timer #{round}: TIMEOUT, tsf now={} target={target} cfg_target={}",
+                    wifi.tsf_time(0).unwrap(),
+                    unsafe { wifi.ll_driver_ref() }.tsf_timer_target(0)
+                );
+            }
+        }
+    }
+    wifi.cancel_tsf_timer(0).unwrap();
+
+    // TBTT of interface 0 with a 100 TU beacon interval. TBTTs happen when the TSF is a multiple
+    // of the interval, so load the TSF to a known phase first.
+    let interval: u16 = 100;
+    let interval_us = interval as u64 * TU as u64;
+    wifi.set_tsf_time(0, 20 * interval_us + 30_000).unwrap();
+    wifi.set_tbtt(0, interval, 0).unwrap();
+    wifi.set_tbtt_enabled(0, true).unwrap();
+    let mut last: Option<u64> = None;
+    for round in 0..6 {
+        let waiter = wifi.wait_for_tbtt(0).unwrap();
+        match select(waiter, Timer::after(Duration::from_secs(2))).await {
+            Either::First(()) => {
+                let t = wifi.tsf_time(0).unwrap();
+                let spacing = last.map(|l| t.wrapping_sub(l)).unwrap_or(0);
+                println!(
+                    "tbtt #{round}: tsf={t} spacing={spacing} us phase={} us",
+                    t % interval_us
+                );
+                last = Some(t);
+            }
+            Either::Second(()) => {
+                println!(
+                    "tbtt #{round}: TIMEOUT, tsf now={}",
+                    wifi.tsf_time(0).unwrap()
+                );
+                break;
+            }
+        }
+    }
+    wifi.set_tbtt_enabled(0, false).unwrap();
+    println!("done");
+    loop {
+        Timer::after_secs(10).await;
+    }
+}

--- a/examples/src/bin/txresult.rs
+++ b/examples/src/bin/txresult.rs
@@ -1,0 +1,92 @@
+//! TX result (PMD) test.
+//!
+//! Alternately transmits a unicast frame to a real AP (which ACKs anything addressed to it) and
+//! to a MAC address that does not exist, and prints the MAC protocol result of each attempt.
+//! Expected: `Ok` for the AP and `AckTimeout` for the bogus address.
+//!
+//! Set `AP_MAC` (e.g. `74:4d:28:1e:be:ea`) and `CHANNEL` at build time; `ESP_LOG=trace` prints the raw PMD.
+#![no_std]
+#![no_main]
+
+use embassy_executor::Spawner;
+use embassy_time::Timer;
+use esp_backtrace as _;
+use esp_hal::efuse::base_mac_address;
+use esp_println::println;
+use esp_wifi_hal::prelude::*;
+use examples::{common_init, embassy_init, get_test_channel, mk_static, wifi_init};
+use ieee80211::{data_frame::builder::DataFrameBuilder, mac_parser::MACAddress, scroll::Pwrite};
+
+fn parse_mac(s: &str) -> [u8; 6] {
+    let mut mac = [0u8; 6];
+    for (i, part) in s.split(':').enumerate().take(6) {
+        mac[i] = u8::from_str_radix(part, 16).unwrap_or(0);
+    }
+    mac
+}
+
+#[esp_rtos::main]
+async fn main(_spawner: Spawner) {
+    let peripherals = common_init();
+    embassy_init(peripherals.TIMG0, peripherals.SW_INTERRUPT);
+    let mut wifi = wifi_init(peripherals.WIFI);
+
+    let channel = get_test_channel();
+    let _ = wifi.set_channel(channel);
+    let my_mac: [u8; 6] = base_mac_address().as_bytes().try_into().unwrap();
+    let ap_mac = parse_mac(option_env!("AP_MAC").unwrap_or("74:4d:28:1e:be:ea"));
+    let bogus_mac = [0x02, 0x13, 0x37, 0x42, 0x42, 0x42];
+
+    // The ACK is expected to be addressed to interface 0, so it must carry our MAC.
+    let _ = wifi.set_filter(0, RxFilterBank::ReceiverAddress, my_mac);
+    let _ = wifi.set_filter_bssid_check(0, false);
+    let _ = wifi.set_scanning_mode(0, ScanningMode::Disabled);
+
+    println!("txresult: ch {channel}, ap {ap_mac:02x?}, bogus {bogus_mac:02x?}");
+
+    let buf = mk_static!([u8; 256], [0x00u8; 256]);
+    let mut round: u32 = 0;
+    loop {
+        for (name, dst, rts) in [
+            ("ap rts", ap_mac, RtsStrategy::DriverControlled),
+            ("ap norts", ap_mac, RtsStrategy::Forced(false)),
+            ("bogus rts", bogus_mac, RtsStrategy::DriverControlled),
+            ("bogus norts", bogus_mac, RtsStrategy::Forced(false)),
+        ] {
+            let written = buf
+                .pwrite(
+                    DataFrameBuilder::new()
+                        .to_ds()
+                        .category_data()
+                        .payload([0x69u8; 5].as_slice())
+                        .destination_address(MACAddress::new(dst))
+                        .source_address(MACAddress::new(my_mac))
+                        .bssid(MACAddress::new(dst))
+                        .build(),
+                    0,
+                )
+                .unwrap();
+            let res = wifi
+                .transmit(
+                    0,
+                    &TxPlcpParameters {
+                        rate: OfdmRate::Mbits6.into(),
+                        ..Default::default()
+                    },
+                    &TxMacParameters {
+                        wait_for_ack: true,
+                        rts_strategy: rts,
+                        ..Default::default()
+                    },
+                    TxErrorBehaviour::Drop,
+                    EdcaAccessCategory::BestEffort.into(),
+                    &mut buf[..written],
+                )
+                .await;
+            println!("#{round} {name}: {res:?}");
+            Timer::after_millis(300).await;
+            wifi.clear_rx_queue();
+        }
+        round += 1;
+    }
+}


### PR DESCRIPTION
This adds experimental support for the ESP32-C3, the first RISC-V chip in esp-wifi-hal. The C3 shares its Wi-Fi 4 MAC with the S2, so most of the driver applies unchanged; the differences are register offsets, a few register layouts, and the fact that part of the proprietary `pp` code lives in ROM on the C3. Everything below has been verified on hardware, including a full WPA2 station connection through FoA. The branch depends on the esp32c3 PAC with the Wi-Fi block from esp-rs/esp-pacs#510, which is why the `[patch.crates-io]` entries point at a rebased copy of that PR on top of the 0.32.3 release; they go away once the PAC is published and esp-hal picks it up. Opened as a draft for that reason, and for early feedback on the approach.

- `lib.rs`, `build.rs`, `Cargo.toml`: `esp32c3` feature, `esp32c3` PAC and `esp-wifi-sys-esp32c3` dependencies, new `osi_funcs_in_rom` and `tsf_timer_present` cfgs
- `ll.rs`: C3 arms for the clock and MAC init masks, RX interrupt bits, the TX slot layout (stride 0x4c, own PLCP1/PLCP2/HT-SIG layouts, `PLCP2` bit 5 must stay set or nothing is transmitted), the TX result (`PMD`) decoding and the PWR interrupt causes; `SYSCON` is `APB_CTRL` on the C3
- `ffi.rs`: `g_osi_funcs_p` is a ROM data variable on the C3 and is written before `hal_init`; `_coex_pti_get` stub; `enable_wifi_agc`/`disable_wifi_agc` link to their `rom_` names
- `async_driver.rs`: RX frames are validated by `sig_len` on the C3, since the length word at header offset 0x18 is S2-specific and dropped every OFDM frame
- new `TsfControl` trait: per-interface TSF read/load/enable, four TSF timers and the TBTT generator, all reporting through the PWR interrupt, which now signals the waiting tasks; the TBTT phase follows the TSF counter as 802.11 defines it (`TSF mod interval == 0`)
- new examples: `sniffer`, `acktest` (hardware auto-ACK), `txresult` (PMD decoding against a real AP) and `tsf_timer_test`

**How the registers were found.** The C3 and S2 blobs from `esp-wifi-sys` were linked into ELFs with `rust-lld --whole-archive` and analysed in Ghidra 12.1 headless mode. A small Ghidra script dumps every instruction that references the MAC MMIO range per function into a CSV; joining the two CSVs on function name (96% of the `libpp` symbols exist on both chips) gives the S2 to C3 offset map for the RX, filter, crypto, interrupt and TX blocks. Individual functions (`mac_tx_set_plcp1`, `lmacProcessTxComplete`, `hal_mac_get_txq_pmd`, `wDev_ProcessFiq`, the `tsf_hal_*` family) were then decompiled to recover bit layouts. Where the blob's `hal_init` sets bits we could not derive statically, the whole MAC register range was dumped at runtime under esp-radio and under this driver and diffed, which is how the TX misc bit was found. The ROM-resident parts showed up as crashes (`g_osi_funcs_p`, `_coex_pti_get`) and were traced through the ROM symbol table.

**How it was tested.** One ESP32-C3 board on USB-JTAG, a laptop with an Intel AX210 in monitor mode and an OpenWrt router (ath10k) as a second independent monitor. RX was cross-checked against the esp-radio sniffer on the same board for DSSS, OFDM and probe requests. TX beacons were captured on the laptop with valid FCS. Hardware auto-ACK was checked with three nodes: the laptop injected unicast data frames to the C3 over a raw `AF_PACKET` socket, the C3 received them and the router captured the ACKs. `txresult` sends unicast frames to the AP and to a nonexistent address with RTS on and off and gets `Ok`, `CtsTimeout` and `AckTimeout` as expected; the raw PMD values are in the code comments. `tsf_timer_test` shows a timer armed one second ahead firing 18 µs after its target and TBTTs every 102400 µs for a 100 TU interval. Finally FoA `sta_single` on this branch connects to a WPA2 network (scan, auth, assoc, 4-way handshake, CCMP), gets a DHCP lease and answers pings.

**Tooling note.** The reverse engineering and the port were carried out with Claude Fable 5.1 (Anthropic) running in Claude Code, directed by me. The model wrote and ran the Ghidra scripts, built the offset map from the MMIO diffs, read the decompilations, wrote the PAC patches, the driver changes and the examples, and drove the hardware loop itself: building, flashing and reading the serial output through an MCP server, running the monitor-mode and injection scripts on the laptop and querying the router over SSH, then diagnosing each failure (ROM OSI table, RX validity word, TX misc bit) from the evidence. I chose the targets, supplied the hardware and network, reviewed the results and decided what to upstream. I am stating this openly so the maintainers can weigh the code accordingly; I have read every change and stand behind it.
